### PR TITLE
Removed assertion failure when poll() on invalid socket

### DIFF
--- a/Sources/Socket/SocketManager.swift
+++ b/Sources/Socket/SocketManager.swift
@@ -257,7 +257,6 @@ extension SocketManager.ManagerState {
                     shouldRead(poll.socket)
                 }
                 if poll.returnedEvents.contains(.invalidRequest) {
-                    assertionFailure("Polled for invalid socket \(poll.socket)")
                     error(.badFileDescriptor, for: poll.socket)
                 }
                 if poll.returnedEvents.contains(.hangup) {


### PR DESCRIPTION
This is a valid error condition that can be hit when, for example, connect() is called and returned error. The socket is in an invalid state but this assertion failure crashes the app before proper error handling can be done elsewhere.