### PR TITLE
Workaround Compiler Bug in CI

### DIFF
--- a/Sources/Socket/SocketManager/AsyncSocketManager.swift
+++ b/Sources/Socket/SocketManager/AsyncSocketManager.swift
@@ -211,9 +211,12 @@ private extension AsyncSocketManager {
             else { return }
         log("Will start monitoring")
         state.isMonitoring = true
+
         // Create top level task to monitor
-        Task.detached(priority: state.configuration.monitorPriority) { [unowned self] in
-            await self.run()
+        // MEMO: Using [weak self] instead of [unowned self] to work around a compiler bug.
+        // This issue only occurs in CI environments, where using [unowned self] causes a compiler crash under certain conditions.
+        Task.detached(priority: state.configuration.monitorPriority) { [weak self] in
+            await self?.run()
         }
     }
     


### PR DESCRIPTION
## Summary

This PR an issue that was occurring in the GitHub Actions (https://github.com/PureSwift/Socket/actions/runs/11842311918). In CI environments, using [unowned self] was causing a compiler crash under specific conditions. As a workaround, the code has been updated to use [weak self] instead, preventing the crash.

example: https://github.com/lyrise/PureSwiftSocket/actions/runs/12567598902

## What does this PR do?

Replaces [unowned self] with [weak self] to avoid a compiler crash in CI environments.
This change ensures stability in CI while the underlying issue is investigated.

## Where should the reviewer start?

Review the change in the startMonitoring function in AsyncSocketManager.swift.
