### PR TITLE
Skip interfaces that have no address

### DIFF
--- a/Sources/Socket/System/NetworkInterface.swift
+++ b/Sources/Socket/System/NetworkInterface.swift
@@ -50,13 +50,10 @@ public extension NetworkInterface {
                     assertionFailure("Unknown interface \(interfaceName)")
                     continue
                 }
-                #if os(Android)
+                // an interface with no address, such as a tunnel, has a null ifa_addr
                 guard let sa_family = value.ifa_addr?.pointee.sa_family else {
                     continue
                 }
-                #else
-                let sa_family = value.ifa_addr.pointee.sa_family
-                #endif
                 guard Address.family.rawValue == sa_family else {
                     continue // incompatible address type
                 }


### PR DESCRIPTION
`getifaddrs` reports an entry with a null `ifa_addr` for an interface that has no address assigned — a tunnel device, for instance. `NetworkInterface.interfaces` read `sa_family` straight through that pointer, so enumerating interfaces trapped with *"Unexpectedly found nil while implicitly unwrapping an Optional value"* on any host that has one.

The `#if os(Android)` branch immediately above already handled exactly this case; the fix is to use that form on every platform and delete the branch. The line just below (`value.ifa_addr.flatMap { ... }`) already treated the pointer as nullable, so this makes the two consistent.

## Testing

Reproduces on a machine with a tailscale interface: `swift test` crashed the test process at `NetworkInterface.swift:58`, taking down the whole run.

With the fix, `swift test --no-parallel` passes 25/25 on Linux — the three `testNetworkInterface*` tests now run rather than aborting the process, which is why the count is up from the 22 that previously survived.

CI never caught this because the GitHub runners have no addressless interface.