### PR TITLE
Fix two races that tear down a healthy socket

### DIFF
--- a/Sources/Socket/SocketManager/AsyncSocketManager.swift
+++ b/Sources/Socket/SocketManager/AsyncSocketManager.swift
@@ -470,10 +470,31 @@ private extension AsyncSocketManager {
         self.error(error, for: fileDescriptor)
     }
     
-    /// Hang up a socket, provided the descriptor still refers to it.
+    /// Hang up a socket, provided the descriptor still refers to it and still reports a hangup.
     func hangup(_ fileDescriptor: SocketDescriptor, socket: SocketState) {
         guard isCurrent(socket, for: fileDescriptor) else { return }
+        guard stillHangsUp(fileDescriptor) else { return }
         hangup(fileDescriptor)
+    }
+
+    /// Whether the descriptor reports a hangup *now*, rather than when it was last polled.
+    ///
+    /// An unconnected socket reports `POLLHUP`, and poll results are acted on from a task that
+    /// runs after polling. A socket polled while `connect` was still in flight is therefore
+    /// established by the time its result is processed, so checking the established flag alone
+    /// cannot tell that stale event apart from a real peer hangup — and acting on it tears down
+    /// a healthy connection, whose next operation then fails with `ESHUTDOWN` or `ECONNABORTED`.
+    ///
+    /// `POLLHUP` is level triggered, so a genuine hangup is still reported here and is acted on
+    /// as before; only the stale observation is filtered out.
+    func stillHangsUp(_ fileDescriptor: SocketDescriptor) -> Bool {
+        // `.hangup` need not be requested: poll always reports it in `revents`.
+        guard let events = try? fileDescriptor._poll(
+            events: [],
+            timeout: 0,
+            retryOnInterrupt: true
+        ).get() else { return false }
+        return events.contains(.hangup)
     }
     
     /// Whether the descriptor is still registered to this very socket, rather than to a newer
@@ -603,6 +624,8 @@ fileprivate extension AsyncSocketManager.SocketState {
     }
     
     func dequeueAll(_ error: Error) {
+        // resume any waiter that arrives after this point, rather than leaving it queued forever
+        terminationError = error
         // cancel all continuations
         for event in eventContinuation.keys {
             while let continuation = dequeue(event) {
@@ -616,6 +639,11 @@ fileprivate extension AsyncSocketManager.SocketState {
     }
 
     func queue(_ event: FileEvents, _ continuation: SocketContinuation<(), Error>) {
+        // the socket was torn down while this waiter was on its way here
+        if let terminationError {
+            continuation.resume(throwing: terminationError)
+            return
+        }
         guard pendingEvents.contains(event) == false else {
             continuation.resume()
             return
@@ -700,7 +728,16 @@ extension AsyncSocketManager {
         /// A socket that has never been connected polls as POLLHUP on Linux, so a hangup can
         /// only be believed once the socket has actually been established.
         var isEstablished = false
-        
+
+        /// The error to resume any further waiter with, once the socket has been torn down.
+        ///
+        /// ``AsyncSocketManager/wait(for:fileDescriptor:)`` registers its continuation from a
+        /// separate task, so a waiter can arrive *after* ``dequeueAll(_:)`` has already drained
+        /// the queue. Recording the teardown lets that late arrival be resumed immediately;
+        /// otherwise it is appended to a state nothing will ever drain again and the caller
+        /// waits forever, still holding a file descriptor number the kernel is free to reuse.
+        var terminationError: Error?
+
         init(
             fileDescriptor: SocketDescriptor,
             manager: AsyncSocketManager,


### PR DESCRIPTION
Fixes two races that tear a healthy socket down, both found by root-causing an intermittent `ESHUTDOWN` / `ECONNABORTED` on a *freshly opened* connection while running the pure-Swift D-Bus test suite. Before this change that suite failed roughly one run in five; after it, 11 consecutive full runs pass.

Both bugs share a shape: state is read at a different moment than the one the decision belongs to.

## 1. Lost wakeup in `wait(for:fileDescriptor:)`

`wait` suspends on a continuation, but registers it with the socket from a *separate* `Task`:

```swift
try await withThrowingContinuation(for: fileDescriptor) { continuation in
    Task(priority: .userInitiated) {
        await socket.queue(events, continuation)
    }
}
```

`discard(_:detach:)` drains the queue via `dequeueAll(_:)`, also from a separate task. If those two interleave the wrong way, `queue` runs *after* `dequeueAll` has already drained everything, appending the continuation to a state that nothing will ever drain again. The caller then waits forever.

That is bad on its own — a permanently suspended task — but the real damage is that the stranded waiter keeps holding a file descriptor *number*. The descriptor itself is closed, so the kernel is free to hand the same number to the next socket, and the stale waiter then registers interest against whichever socket now owns it.

`SocketState` now records the teardown error, and `queue` resumes a late arrival with it immediately rather than enqueuing it.

Measured directly: with the D-Bus client instrumented to report when its read loop failed to stop after `close()`, this fired 4–7 times per test run, and every failing run was one where it fired.

## 2. A stale `POLLHUP` acted on after the socket connects

An unconnected socket reports `POLLHUP` — `Socket.init` registers the descriptor with the event queue *before* `connect`, so there is a window where every socket polls as hung up.

The existing guard checked `isEstablished` before honoring a hangup, but it checked it in the task that runs *after* polling. So:

1. Poll observes `POLLHUP` — the socket has not connected yet.
2. `connect` completes and calls `markEstablished()`.
3. The deferred task reads `isEstablished == true` and tears the socket down.

The check cannot distinguish a stale observation from a real hangup, because by the time it runs the flag says "established" in both cases. The next operation on that socket then fails with `ESHUTDOWN` from `socket(for:)`, or `ECONNABORTED` from the drained queue.

`hangup(_:socket:)` now re-polls the descriptor and only proceeds if it *still* reports a hangup. `POLLHUP` is level triggered, so a genuine hangup is reported again and is acted on exactly as before; only the stale observation is filtered.

Captured in the act, with the harmful event and the harmless ones side by side:

```
HUP-EVENT 7  established=true  listening=false events=[.hangup]                 <- tore down a healthy socket
HUP-EVENT 11 established=false listening=false events=[.read, .error, .hangup]  <- correctly skipped
```

The `fd 7` line was immediately followed by the test failure. With the re-check in place the same event still occurs and is now correctly ignored.

## Note

Neither fix ships with a regression test. Both are timing races between three tasks with no injection point to drive them deterministically, and a test that merely opens and closes sockets in a loop would reproduce them only probabilistically. They are verified by the D-Bus suite, which exercises the pattern heavily: 1-in-5 failures before, 11 consecutive clean runs after.

The pre-existing failures on this repo — the force unwrap at `NetworkInterface.swift:58`, and the fixed-port and fixed-path tests colliding with leftovers from earlier runs — are untouched here and fail the same way on `main`.
